### PR TITLE
Extra space characters in Makefile causing build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 obj-y := dvb-usb/
 
-KVER ?= $(shell uname -r)  
+KVER ?= $(shell uname -r)
 KDIR := /lib/modules/$(KVER)/build
 
 #KDIR=/root/raspberrypi/linux/


### PR DESCRIPTION
The error is look like:
```
$ make V=1
make=make
KDIR=/lib/modules/4.19.147-rivoreo-amd64  /build
PWD=xxxxxx/src/dcdtv330
make  -C /lib/modules/4.19.147-rivoreo-amd64  /build M=/root/src/dcdtv330 modules
make[1]: Entering directory '/usr/lib/modules/4.19.147-rivoreo-amd64'
make[1]: *** No rule to make target '/build'.  Stop.
make[1]: Leaving directory '/usr/lib/modules/4.19.147-rivoreo-amd64'
make: *** [Makefile:13: all] Error 2
```